### PR TITLE
fix: adicionar paginação no DynamoDB Scan/Query para corrigir listagem de álbuns e fotos

### DIFF
--- a/lib/photos.js
+++ b/lib/photos.js
@@ -1,22 +1,104 @@
+// ============================================================================
 // lib/photos.js
+// ============================================================================
+// Responsável: Operações de leitura e filtragem de fotos no DynamoDB
+// Tabela usada: photos (contém todas as fotos de todos os álbuns)
+// Estrutura esperada do item:
+//   - albumCode: código do álbum (ex: "202312" para dezembro/2023)
+//   - photoKey: chave da foto no S3
+//   - deletedAt: data de exclusão (null = foto ativa, ISO string = deletada)
+// ============================================================================
+
+// Importa o comando QueryCommand do SDK v3 do DynamoDB
+// QueryCommand é usado para buscar itens usando a Primary Key (mais eficiente que Scan)
 import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+
+// Importa o cliente do DynamoDB já configurado (região, credentials, etc.)
 import { ddb } from "./dynamo";
 
+// Nome da tabela de fotos, vem da variável de ambiente
+// Ex: "photos", "myapp-photos-dev", etc.
 const TABLE = process.env.DYNAMO_TABLE_PHOTOS;
 
+/**
+ * Lista todas as fotos de um álbum específico
+ * 
+ * @param {string} albumCode - Código do álbum no formato "AAAAMM" (ex: "202312")
+ * @returns {Promise<Array>} Array de fotos ativas (não deletadas) do álbum
+ * 
+ * COMO FUNCIONA:
+ * 1. Usa QueryCommand para buscar todos os itens onde albumCode = código informado
+ * 2. Query é mais eficiente que Scan porque usa a Primary Key da tabela
+ * 3. Filtra no JavaScript apenas fotos onde deletedAt é null/undefined (fotos vivas)
+ * 4. Lida com paginação automática (DynamoDB retorna máx 1MB por query)
+ */
 export async function listPhotosByAlbum(albumCode) {
-  const command = new QueryCommand({
-    TableName: TABLE,
-    KeyConditionExpression: "albumCode = :code",
-    ExpressionAttributeValues: {
-      ":code": albumCode,
-    },
-    ScanIndexForward: true,
-  });
+    // Array para armazenar TODAS as fotos (incluindo múltiplas páginas)
+    let allItems = [];
+    
+    // Variável para controlar a paginação
+    // LastEvaluatedKey vem do DynamoDB quando há mais dados para buscar
+    let lastEvaluatedKey = undefined;
+    let iteration = 0; // Contador de páginas para o log
 
-  const res = await ddb.send(command);
-  const items = res.Items || [];
+    // 🔵 LOG 1: Início da busca (saber qual álbum está sendo carregado)
+    console.log(`[photos.js] Buscando fotos do álbum: ${albumCode}`);
+    
+        // Loop que continua enquanto houver mais páginas de resultados
+    // O DynamoDB retorna no máximo 1MB de dados por Query/Scan
+    // Se tiver mais dados, retorna LastEvaluatedKey para continuar de onde parou
+    do {
+        iteration++; // Incrementa o contador de páginas
+        // Cria o comando de Query com os parâmetros:
+        const command = new QueryCommand({
+            TableName: TABLE,                    // Nome da tabela
+            KeyConditionExpression: "albumCode = :code",  // Busca por albumCode
+            ExpressionAttributeValues: {
+                ":code": albumCode,              // Valor do albumCode a buscar
+            },
+            ScanIndexForward: true,              // true = ordem crescente, false = decrescente
+            ExclusiveStartKey: lastEvaluatedKey, // Continua da última posição (paginação)
+        });
 
-  // Filtra fotos que não foram marcadas como deletadas
-  return items.filter((item) => !item.deletedAt);
+        // 🔵 LOG 2: Antes de executar a query (saber se tem paginação)
+        console.log(`[photos.js] Página ${iteration} - Executando Query no DynamoDB...`);
+
+        // Executa a query no DynamoDB
+        const res = await ddb.send(command);
+        
+        // Adiciona os itens retornados nesta página ao array principal
+        // Items pode ser undefined se não houver resultados
+        allItems = allItems.concat(res.Items || []);
+        
+        // Atualiza lastEvaluatedKey com a posição atual
+        // Se for undefined, o loop termina (última página)
+        lastEvaluatedKey = res.LastEvaluatedKey;
+
+        // 🔵 LOG 3: Após receber resposta (quantos itens vieram nesta página)
+        console.log(
+            `[photos.js] Página ${iteration} - Recebidos: ${res.Items?.length || 0} fotos | ` +
+            `Total acumulado: ${allItems.length} fotos | ` +
+            `Mais páginas: ${!!lastEvaluatedKey}`
+        );
+
+        // Log opcional para debug (remover em produção)
+        // console.log(`Página processada. Total acumulado: ${allItems.length} fotos`);
+
+    } while (lastEvaluatedKey); // Enquanto houver mais páginas, continua
+
+    // Filtra as fotos para retornar APENAS as ativas (não deletadas)
+    // deletedAt é null/undefined para fotos ativas
+    // deletedAt é uma string ISO (ex: "2024-01-15T10:30:00Z") para fotos deletadas
+    const activePhotos = allItems.filter((item) => !item.deletedAt);
+
+    // 🔵 LOG 4: Resultado final (quantas fotos ativas após filtrar deletadas)
+    console.log(
+        `[photos.js] Álbum ${albumCode} - ` +
+        `Total bruto: ${allItems.length} | ` +
+        `Fotos ativas (filtradas): ${activePhotos.length} | ` +
+        `Fotos deletadas: ${allItems.length - activePhotos.length}`
+    );
+
+    // Retorna apenas as fotos ativas
+    return activePhotos;
 }

--- a/pages/api/album/list-albums.js
+++ b/pages/api/album/list-albums.js
@@ -1,57 +1,168 @@
+// ============================================================================
 // pages/api/album/list-albums.js
+// ============================================================================
+// Rota da API: GET /api/album/list-albums
+// Responsável: Listar todos os álbuns que possuem pelo menos UMA foto ativa
+// Retorna: Array de códigos de álbuns únicos (ex: ["202312", "202401", "202402"])
+// ============================================================================
 
-// Importa o comando de Scan do DynamoDB DocumentClient
+// Importa o comando Scan do DynamoDB DocumentClient v3
+// ScanCommand lê TODOS os itens da tabela (diferente de Query que usa Primary Key)
+// É necessário usar Scan aqui porque queremos varrer toda a tabela para encontrar
+// álbuns únicos, não estamos buscando por uma chave específica
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
-// Importa o client configurado do Dynamo (lib/dynamo.js)
+
+// Importa o cliente do DynamoDB já configurado
+// Arquivo contém: região, credentials, endpoint (se LocalStack/DynamoDB Local)
 import { ddb } from "../../../lib/dynamo";
 
-// Nome da tabela de fotos (vem do .env)
+// Nome da tabela de fotos, vem da variável de ambiente
+// Deve ser a mesma tabela usada no photos.js
 const TABLE = process.env.DYNAMO_TABLE_PHOTOS;
 
+/**
+ * Handler da rota GET /api/album/list-albums
+ * 
+ * @param {Object} req - Requisição HTTP (Next.js API)
+ * @param {Object} res - Resposta HTTP (Next.js API)
+ * 
+ * O QUE FAZ:
+ * 1. Varre toda a tabela photos usando ScanCommand
+ * 2. Coleta códigos únicos de álbuns que têm pelo menos 1 foto ativa
+ * 3. Ignora fotos deletadas (deletedAt preenchido)
+ * 4. Retorna lista ordenada de códigos de álbuns
+ * 
+ * POR QUE USAR SCAN AQUI:
+ * - Precisamos varrer TODA a tabela, não há como usar Query sem uma Primary Key específica
+ * - Queremos descobrir quais álbuns existem, não buscar um álbum específico
+ */
 export default async function handler(req, res) {
-  // Só aceitamos requisições GET nessa rota
-  if (req.method !== "GET") {
-    return res.status(405).json({ error: "Method not allowed" });
-  }
-
-  try {
-    // Monta o comando para fazer um Scan na tabela inteira,
-    // mas projetando apenas os campos necessários:
-    // - albumCode: código do álbum (mmaaaa)
-    // - deletedAt: data de exclusão (se existir)
-    const command = new ScanCommand({
-      TableName: TABLE,
-      ProjectionExpression: "albumCode, deletedAt",
-    });
-
-    // Executa o Scan no DynamoDB
-    const data = await ddb.send(command);
-
-    // Usamos um Set para armazenar apenas códigos de álbuns únicos
-    // que ainda tenham pelo menos UMA foto "viva" (sem deletedAt)
-    const aliveAlbums = new Set();
-
-    for (const item of data.Items || []) {
-      // Se o item tem albumCode e NÃO tem deletedAt,
-      // significa que pertence a um álbum com fotos ativas
-      if (item.albumCode && !item.deletedAt) {
-        aliveAlbums.add(item.albumCode);
-      }
+    // ========================================================================
+    // VALIDAÇÃO DO MÉTODO HTTP
+    // ========================================================================
+    // Esta API só aceita requisições GET
+    // Se tentar usar POST, PUT, DELETE, etc., retorna erro 405
+    if (req.method !== "GET") {
+        return res.status(405).json({ error: "Method not allowed" });
     }
 
-    // Convertemos o Set em array e ordenamos (ex.: ["012015", "022026", ...])
-    const albums = Array.from(aliveAlbums).sort();
+    try {
+        // 🔵 LOG 1: Início do processo de listagem
+        console.log(`[list-albums.js] Iniciando listagem de álbuns - Tabela: ${TABLE}`);
+        // ====================================================================
+        // COLETA DE ÁLBUNS ATIVOS COM PAGINAÇÃO
+        // ====================================================================
+        // Usamos Set em vez de Array para evitar duplicatas automaticamente
+        // Um álbum pode ter centenas de fotos, mas queremos o código apenas uma vez
+        const aliveAlbums = new Set();
+        
+        // Variável para controlar a paginação do Scan
+        // LastEvaluatedKey indica onde parar na próxima iteração
+        let lastEvaluatedKey = undefined;
+        let iteration = 0; // Contador de páginas para o log
 
-    // Retornamos no formato esperado pelo front: { albums: [...] }
-    return res.status(200).json({ albums });
-  } catch (err) {
-    // Em caso de erro na consulta, logamos no servidor
-    console.error("Erro ao listar álbuns", err);
+        // 🔵 LOG 2: Início do Scan
+        console.log(`[list-albums.js] Iniciando Scan no DynamoDB...`);
 
-    // E retornamos 500 com detalhes básicos do erro
-    return res.status(500).json({
-      error: "Erro ao listar álbuns",
-      details: err.message || String(err),
-    });
-  }
+        // Loop de paginação: executa enquanto houver mais dados
+        // O DynamoDB retorna no máximo 1MB por Scan, então precisamos de loop
+        do {
+            // Cria o comando de Scan com:
+            iteration++; // Incrementa contador de páginas
+            const command = new ScanCommand({
+                TableName: TABLE,                    // Nome da tabela
+                ProjectionExpression: "albumCode, deletedAt",  // Campos a retornar
+                // ProjectionExpression otimiza a query trazendo apenas o necessário
+                // Reduz custo de leitura e melhora performance
+                
+                ExclusiveStartKey: lastEvaluatedKey, // Continua da última posição
+                // Na primeira execução é undefined, então começa do início
+            });
+
+            // 🔵 LOG 3: Antes de executar cada página do Scan
+            console.log(`[list-albums.js] Página ${iteration} - Executando Scan...`);
+
+            // Executa o Scan no DynamoDB
+            const data = await ddb.send(command);
+            
+            // =================================================================
+            // PROCESSAMENTO DOS ITENS DESTA PÁGINA
+            // =================================================================
+            // Itera sobre cada foto retornada nesta página do Scan
+            for (const item of data.Items || []) {
+                // Verifica se a foto atende aos critérios:
+                // 1. Tem albumCode definido (existe um álbum associado)
+                // 2. NÃO tem deletedAt (foto ainda não foi deletada)
+                //    - deletedAt = null/undefined → foto ativa
+                //    - deletedAt = string ISO → foto deletada logicamente
+                if (item.albumCode && !item.deletedAt) {
+                    // Adiciona o código do álbum ao Set
+                    // Set automaticamente ignora duplicatas
+                    // Ex: se "202312" já existe, não adiciona novamente
+                    aliveAlbums.add(item.albumCode);
+                }
+            }
+
+            // =================================================================
+            // ATUALIZA PONTEIRO DE PAGINAÇÃO
+            // =================================================================
+            // LastEvaluatedKey contém a chave do último item processado
+            // Se for undefined, significa que chegamos ao final da tabela
+            lastEvaluatedKey = data.LastEvaluatedKey;
+
+            // 🔵 LOG 4: Após processar cada página
+            console.log(
+                `[list-albums.js] Página ${iteration} - ` +
+                `Itens nesta página: ${data.Items?.length || 0} | ` +
+                `Álbuns únicos encontrados: ${aliveAlbums.size} | ` +
+                `Mais páginas: ${!!lastEvaluatedKey}`
+            );
+
+            // Log opcional para debug (útil para testar paginação)
+            // console.log(`Página Scan processada. Álbuns únicos encontrados: ${aliveAlbums.size}`);
+            // console.log(`Há mais páginas? ${!!lastEvaluatedKey}`);
+
+        } while (lastEvaluatedKey); // Continua enquanto houver mais páginas
+
+        // ====================================================================
+        // PREPARAÇÃO DA RESPOSTA
+        // ====================================================================
+        // Converte o Set para Array
+        // Set não tem ordem garantida, então ordenamos alfabeticamente/numericamente
+        // Ex: ["202401", "202312", "202402"] → ["202312", "202401", "202402"]
+        const albums = Array.from(aliveAlbums).sort();
+
+        // 🔵 LOG 5: Resultado final da listagem
+        console.log(
+            `[list-albums.js] Conclusão - ` +
+            `Total de páginas processadas: ${iteration} | ` +
+            `Álbuns únicos encontrados: ${albums.length} | ` +
+            `Álbuns: ${JSON.stringify(albums)}`
+        );
+
+        // Retorna resposta de sucesso com a lista de álbuns
+        // Formato esperado pelo front-end em pages/album.js
+        return res.status(200).json({ albums });
+
+    } catch (err) {
+        // 🔵 LOG 6: Em caso de erro
+        console.error(`[list-albums.js] ERRO na listagem de álbuns:`, err);
+        
+        return res.status(500).json({
+            error: "Erro ao listar álbuns",
+            details: err.message || String(err),
+        });
+        // ====================================================================
+        // TRATAMENTO DE ERROS
+        // ====================================================================
+        // Loga o erro no servidor (aparece nos logs da Vercel/CloudWatch)
+        console.error("Erro ao listar álbuns:", err);
+        
+        // Retorna erro 500 para o cliente com detalhes
+        // Em produção, evite expor detalhes internos do erro
+        return res.status(500).json({
+            error: "Erro ao listar álbuns",
+            details: err.message || String(err),
+        });
+    }
 }


### PR DESCRIPTION
## 🐛 Problema Resolvido

Álbuns e pastas de fotos não apareciam completamente na listagem. O DynamoDB possui limite de **1MB por operação Scan/Query**, causando perda de dados quando a tabela ultrapassa esse tamanho.

**Impacto:**
- ❌ **Antes:** Apenas 38 álbuns listados (primeiros 6871 itens)
- ✅ **Depois:** **98 álbuns listados** (11.676 itens totais)
- 📉 **Dados perdidos:** 41% dos registros (4805 itens não eram varridos)

---

## ✅ Solução

Implementada paginação com `LastEvaluatedKey` em dois pontos críticos:

### 1. `pages/api/album/list-albums.js`
Loop de paginação no `ScanCommand` para varrer toda a tabela e coletar álbuns únicos:
```javascript
do {
    const command = new ScanCommand({
        TableName: TABLE,
        ProjectionExpression: "albumCode, deletedAt",
        ExclusiveStartKey: lastEvaluatedKey,
    });
    const data = await ddb.send(command);
    // Processa itens...
    lastEvaluatedKey = data.LastEvaluatedKey;
} while (lastEvaluatedKey);
```
📊 Evidências de Testes
Logs de execução (dev local):

```[list-albums.js] Página 1 - Itens: 6871 | Álbuns únicos: 38 | Mais páginas: true
[list-albums.js] Página 2 - Itens: 4805 | Álbuns únicos: 98 | Mais páginas: false
[list-albums.js] Conclusão - Total de páginas: 2 | Álbuns únicos: 98
```
---
## Resultados:

✅ Todos os 98 álbuns listados (de 012004 a 122025 + SEM-DATA)

✅ Álbum SEM-DATA com 2504 fotos carrega corretamente

✅ Filtro deletedAt funcionando (fotos deletadas são excluídas)---
## 🔄 Arquivos Alterados
Arquivo | Mudança | Impacto
---|---|---
```lib/photos.js``` | Paginação no Query | Álbuns grandes não perdem fotos
```pages/api/alnum/list-albums.js``` | Paginação no Scan | Todos álbuns são listados

---
## 🧪 Como Testar
```# 1. Listar todos os álbuns
curl http://localhost:3000/api/album/list-albums

# 2. Carregar álbum com muitas fotos
curl http://localhost:3000/api/album/SEM-DATA

# 3. Verificar logs no terminal
# - Deve mostrar múltiplas páginas processadas
# - Total de álbuns/fotos deve bater com DynamoDB Console
```

---
## 📝 Notas
✅ Backward compatible: Sem breaking changes

✅ Sem migração: Nenhuma alteração no schema do DynamoDB

✅ Logs adicionados: Para monitoramento em produção (podem ser removidos depois)

Otimizações Futuras (Backlog)
- [ ] Criar GSI para evitar Scan completo da tabela

- [ ] Implementar cache (Redis/DAX) para listagem de álbuns

- [ ] Remover logs de debug em produção