### PR TITLE
Desativar otimização de imagens da Vercel para corrigir erro 402

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@
 const nextConfig = {
   // ✅ Configuração de imagens (para next/image)
   images: {
+    unoptimized: true, // Desativa otimização automática (opcional, dependendo do uso)
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Contexto

A aplicação estava retornando `402 PAYMENT_REQUIRED` ao carregar novas imagens
otimizadas pela Vercel, devido ao limite de Image Optimization do plano Hobby.

Como as imagens já estão em CDNs/buckets externos e não precisamos, neste
momento, da otimização automática da Vercel, foi decidido desativar essa
funcionalidade globalmente.

## O que foi feito

- Adicionado `images.unoptimized = true` no `next.config.js`
- Mantida a configuração de `remotePatterns` para:
  - cdn.jsdelivr.net
  - img.shields.io
  - komarev.com
  - jnths-family-album.s3.sa-east-1.amazonaws.com
- Preservadas as configurações de headers de segurança e cache já existentes

## Impacto

- Novas imagens deixam de passar pelo pipeline de otimização da Vercel
- O erro `402 PAYMENT_REQUIRED` deixa de ocorrer para novos requests de imagem
- As imagens passam a ser servidas “as-is” pelas origens configuradas
- Pequeno aumento potencial de banda/tamanho transferido, em troca de estabilidade

## Como testar

1. Fazer deploy desta branch na Vercel.
2. Acessar páginas que utilizam `<Image>` com fontes remotas (CDN/S3).
3. Confirmar que:
   - As imagens carregam normalmente (sem erro 402).
   - As URLs deixam de passar por `/_next/image` (opcionalmente inspecionando no DevTools).
