### PR TITLE
feat(security): controle de acesso granular nas APIs e suite de testes completa

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,7 @@
+AWS_REGION=sa-east-1
+AWS_S3_BUCKET=test-bucket
+DYNAMO_TABLE_WHITELIST=whitelist
+DYNAMO_TABLE_PHOTOS=photos
+OWNER_EMAIL=owner@test.com
+NEXTAUTH_SECRET=test-secret
+NEXTAUTH_URL=http://localhost:3000

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,9 @@
 import "@testing-library/jest-dom";
 import "whatwg-fetch";
+
+// next/jest does not load .env.local in test mode — set defaults for module-level constants
+process.env.AWS_REGION = process.env.AWS_REGION || "sa-east-1";
+process.env.AWS_S3_BUCKET = process.env.AWS_S3_BUCKET || "test-bucket";
+process.env.DYNAMO_TABLE_WHITELIST = process.env.DYNAMO_TABLE_WHITELIST || "whitelist";
+process.env.DYNAMO_TABLE_PHOTOS = process.env.DYNAMO_TABLE_PHOTOS || "photos";
+process.env.OWNER_EMAIL = process.env.OWNER_EMAIL || "jonathas.lima.cunha@gmail.com";

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,9 +1,2 @@
 import "@testing-library/jest-dom";
 import "whatwg-fetch";
-
-// next/jest does not load .env.local in test mode — set defaults for module-level constants
-process.env.AWS_REGION = process.env.AWS_REGION || "sa-east-1";
-process.env.AWS_S3_BUCKET = process.env.AWS_S3_BUCKET || "test-bucket";
-process.env.DYNAMO_TABLE_WHITELIST = process.env.DYNAMO_TABLE_WHITELIST || "whitelist";
-process.env.DYNAMO_TABLE_PHOTOS = process.env.DYNAMO_TABLE_PHOTOS || "photos";
-process.env.OWNER_EMAIL = process.env.OWNER_EMAIL || "jonathas.lima.cunha@gmail.com";

--- a/pages/api/album/add-photo.js
+++ b/pages/api/album/add-photo.js
@@ -1,14 +1,40 @@
 // pages/api/album/add-photo.js
 
-import { PutCommand } from "@aws-sdk/lib-dynamodb";
-import { ddb } from "../../../lib/dynamo"; // ajuste o caminho conforme seu projeto
+import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]";
+import { ddb } from "../../../lib/dynamo";
 
 const TABLE = process.env.DYNAMO_TABLE_PHOTOS;
+const OWNER_EMAIL = process.env.OWNER_EMAIL || "";
+const WHITELIST_TABLE = process.env.DYNAMO_TABLE_WHITELIST;
 
 export default async function handler(req, res) {
   // Só aceita POST
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user?.email) {
+    return res.status(401).json({ error: "Not authenticated" });
+  }
+
+  const email = session.user.email.toLowerCase();
+  const isOwner = OWNER_EMAIL && email === OWNER_EMAIL.toLowerCase();
+
+  if (!isOwner) {
+    try {
+      const wl = await ddb.send(new GetCommand({
+        TableName: WHITELIST_TABLE,
+        Key: { email },
+      }));
+      if (!wl?.Item?.canUploadPhotos) {
+        return res.status(403).json({ error: "Not allowed" });
+      }
+    } catch {
+      return res.status(403).json({ error: "Not allowed" });
+    }
   }
 
   try {

--- a/pages/api/album/delete.js
+++ b/pages/api/album/delete.js
@@ -1,13 +1,14 @@
 import { getServerSession } from "next-auth";
 import { S3Client, DeleteObjectCommand } from "@aws-sdk/client-s3";
-import { UpdateCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, UpdateCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { authOptions } from "../auth/[...nextauth]";
 import { ddb } from "../../../lib/dynamo";
 
 const region = process.env.AWS_REGION;
 const bucket = process.env.AWS_S3_BUCKET;
 const TABLE = process.env.DYNAMO_TABLE_PHOTOS;
-const OWNER_EMAIL = "jonathas.lima.cunha@gmail.com";
+const OWNER_EMAIL = process.env.OWNER_EMAIL || "";
+const WHITELIST_TABLE = process.env.DYNAMO_TABLE_WHITELIST;
 
 const s3 = new S3Client({
   region,
@@ -24,12 +25,25 @@ export default async function handler(req, res) {
 
   const session = await getServerSession(req, res, authOptions);
 
-  if (
-    !session ||
-    !session.user ||
-    session.user.email.toLowerCase() !== OWNER_EMAIL.toLowerCase()
-  ) {
-    return res.status(403).json({ error: "Not allowed" });
+  if (!session?.user?.email) {
+    return res.status(401).json({ error: "Not authenticated" });
+  }
+
+  const email = session.user.email.toLowerCase();
+  const isOwner = OWNER_EMAIL && email === OWNER_EMAIL.toLowerCase();
+
+  if (!isOwner) {
+    try {
+      const wl = await ddb.send(new GetCommand({
+        TableName: WHITELIST_TABLE,
+        Key: { email },
+      }));
+      if (!wl?.Item?.canDeletePhotos) {
+        return res.status(403).json({ error: "Not allowed" });
+      }
+    } catch {
+      return res.status(403).json({ error: "Not allowed" });
+    }
   }
 
   const { key, albumCode } = req.body || {};

--- a/pages/api/album/list-albums.js
+++ b/pages/api/album/list-albums.js
@@ -152,17 +152,5 @@ export default async function handler(req, res) {
             error: "Erro ao listar álbuns",
             details: err.message || String(err),
         });
-        // ====================================================================
-        // TRATAMENTO DE ERROS
-        // ====================================================================
-        // Loga o erro no servidor (aparece nos logs da Vercel/CloudWatch)
-        console.error("Erro ao listar álbuns:", err);
-        
-        // Retorna erro 500 para o cliente com detalhes
-        // Em produção, evite expor detalhes internos do erro
-        return res.status(500).json({
-            error: "Erro ao listar álbuns",
-            details: err.message || String(err),
-        });
     }
 }

--- a/pages/api/album/list.js
+++ b/pages/api/album/list.js
@@ -9,7 +9,7 @@ import { logger } from '../../../lib/logger';
 
 const region = process.env.AWS_REGION;
 const bucket = process.env.AWS_S3_BUCKET;
-const prefix = process.env.AWS_S3_ALBUM_PREFIX || "album/";
+const prefix = process.env.AWS_S3_ALBUM_PREFIX || "albuns/";
 
 const s3 = new S3Client({
   region,

--- a/pages/api/album/upload-url.js
+++ b/pages/api/album/upload-url.js
@@ -8,6 +8,9 @@ import { authOptions } from "../auth/[...nextauth]";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { ddb } from "../../../lib/dynamo";
+
 // 🔧 Lê configurações do S3 a partir das variáveis de ambiente
 //    IMPORTANTE: essas envs precisam estar definidas tanto em .env.local (dev)
 //    quanto nas Environment Variables da Vercel (Production).
@@ -16,8 +19,8 @@ const BUCKET = process.env.AWS_S3_BUCKET;
 // Prefixo padrão para chaves no bucket (caso o front não envie s3Key explícito)
 const PREFIX = process.env.AWS_S3_ALBUM_PREFIX || "album/";
 
-// 🔐 Somente este e-mail poderá gerar URLs de upload
-const ALLOWED_EMAIL = "jonathas.lima.cunha@gmail.com";
+const OWNER_EMAIL = process.env.OWNER_EMAIL || "";
+const WHITELIST_TABLE = process.env.DYNAMO_TABLE_WHITELIST;
 
 // ✅ Cliente S3 usado apenas no backend (API routes)
 //    Aqui usamos credenciais via env (IAM user/role com permissão no bucket).
@@ -64,11 +67,23 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: "Not authenticated" });
   }
 
-  // 🔐 Compara email logado com o dono (case-insensitive para evitar ruído)
   const userEmail = session.user.email.toLowerCase();
-  if (userEmail !== ALLOWED_EMAIL.toLowerCase()) {
-    console.warn("[UploadURL] Acesso negado para:", userEmail);
-    return res.status(403).json({ error: "Not allowed" });
+  const isOwner = OWNER_EMAIL && userEmail === OWNER_EMAIL.toLowerCase();
+
+  if (!isOwner) {
+    try {
+      const wl = await ddb.send(new GetCommand({
+        TableName: WHITELIST_TABLE,
+        Key: { email: userEmail },
+      }));
+      if (!wl?.Item?.canUploadPhotos) {
+        console.warn("[UploadURL] Acesso negado para:", userEmail);
+        return res.status(403).json({ error: "Not allowed" });
+      }
+    } catch {
+      console.warn("[UploadURL] Erro ao verificar permissão para:", userEmail);
+      return res.status(403).json({ error: "Not allowed" });
+    }
   }
 
   // 📦 Lê dados enviados pelo front:

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -53,6 +53,8 @@ function checkLoginRateLimit(email) {
 // ===================================================================
 // CONFIGURAÇÃO DO NEXTAUTH
 // ===================================================================
+const OWNER_EMAIL = process.env.OWNER_EMAIL || "";
+
 export const authOptions = {
   // Provedores de autenticação disponíveis (por enquanto, apenas Google)
   providers: [
@@ -89,7 +91,6 @@ export const authOptions = {
       }
 
       const email = user.email.toLowerCase();
-      const OWNER_EMAIL = "jonathas.lima.cunha@gmail.com";
 
       // 2) Dono sempre tem acesso (bypass de whitelist)
       //    Isso garante que você sempre consegue entrar para manutenção,

--- a/pages/api/whitelist/list.js
+++ b/pages/api/whitelist/list.js
@@ -37,20 +37,20 @@ export default async function handler(req, res) {
   try {
     console.info("[Whitelist:list] Fazendo Scan na tabela:", TABLE);
 
-    const command = new ScanCommand({
-      TableName: TABLE,
-    });
+    let items = [];
+    let lastKey = undefined;
+    do {
+      const data = await ddb.send(new ScanCommand({
+        TableName: TABLE,
+        ExclusiveStartKey: lastKey,
+      }));
+      items = items.concat(data.Items || []);
+      lastKey = data.LastEvaluatedKey;
+    } while (lastKey);
 
-    const data = await ddb.send(command);
+    console.info("[Whitelist:list] Itens encontrados:", items.length);
 
-    console.info(
-      "[Whitelist:list] Itens encontrados:",
-      data.Items ? data.Items.length : 0
-    );
-
-    return res.status(200).json({
-      items: data.Items || [],
-    });
+    return res.status(200).json({ items });
   } catch (err) {
     console.error("[Whitelist:list] Erro ao listar whitelist", err);
     return res.status(500).json({

--- a/tests/AlbumDetailPage.test.js
+++ b/tests/AlbumDetailPage.test.js
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import AlbumDetailPage from "../pages/album/[albumCode]";
+import { useSession } from "next-auth/react";
+
+jest.mock("next-auth/react");
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    query: { albumCode: "012025" },
+    pathname: "/album/[albumCode]",
+  }),
+}));
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ src, alt, ...props }) => <img src={src} alt={alt} {...props} />,
+}));
+
+describe("Página /album/[albumCode]", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockReturnValue(new Promise(() => {}));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("mostra mensagem de carregando enquanto a sessão está carregando", () => {
+    useSession.mockReturnValue({ data: null, status: "loading" });
+    render(<AlbumDetailPage />);
+    expect(screen.getByText(/carregando\.\.\./i)).toBeInTheDocument();
+  });
+
+  it("retorna null e redireciona quando não há sessão", () => {
+    useSession.mockReturnValue({ data: null, status: "unauthenticated" });
+    const { container } = render(<AlbumDetailPage />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("mostra mensagem de verificação de permissão enquanto allowed ainda é null", () => {
+    useSession.mockReturnValue({
+      data: { user: { name: "Jonathas", email: "alguem@example.com" } },
+      status: "authenticated",
+    });
+    render(<AlbumDetailPage />);
+    expect(
+      screen.getByText(/verificando permissão de acesso/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/AlbumPage.test.js
+++ b/tests/AlbumPage.test.js
@@ -1,29 +1,34 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import AlbumPage from "../pages/album";
 import { useSession } from "next-auth/react";
 
 jest.mock("next-auth/react");
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    query: {},
+    pathname: "/album",
+  }),
+}));
 
 describe("Página /album", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("mostra mensagem de carregando enquanto a sessão está carregando", () => {
-    useSession.mockReturnValue({
-      data: null,
-      status: "loading",
-    });
-
+    useSession.mockReturnValue({ data: null, status: "loading" });
     render(<AlbumPage />);
-
     expect(screen.getByText(/carregando\.\.\./i)).toBeInTheDocument();
   });
 
   it("mostra tela de login quando não há sessão", () => {
-    useSession.mockReturnValue({
-      data: null,
-      status: "unauthenticated",
-    });
-
+    useSession.mockReturnValue({ data: null, status: "unauthenticated" });
     render(<AlbumPage />);
-
     expect(
       screen.getByText(/faça login com sua conta google autorizada/i)
     ).toBeInTheDocument();
@@ -33,45 +38,37 @@ describe("Página /album", () => {
   });
 
   it("mostra mensagem de verificação de permissão enquanto allowed ainda é null", () => {
-    // status autenticado, mas allowed começa como null
     useSession.mockReturnValue({
-      data: {
-        user: {
-          name: "Jonathas",
-          email: "alguem@example.com",
-        },
-      },
+      data: { user: { name: "Jonathas", email: "alguem@example.com" } },
       status: "authenticated",
     });
-
-    // IMPORTANTE: não chamamos useEffect nem avançamos o estado allowed no teste,
-    // então o return que será executado é o do allowed === null
+    global.fetch.mockReturnValue(new Promise(() => {})); // nunca resolve
     render(<AlbumPage />);
-
     expect(
       screen.getByText(/verificando permissão de acesso/i)
     ).toBeInTheDocument();
   });
 
-  it("renderiza o título principal do álbum quando usuário dono e allowed === true", () => {
-    // Dono: email = OWNER_EMAIL
+  it("renderiza área administrativa quando usuário é o dono", async () => {
     useSession.mockReturnValue({
-      data: {
-        user: {
-          name: "Jonathas",
-          email: "jonathas.lima.cunha@gmail.com",
-        },
-      },
+      data: { user: { name: "Jonathas", email: process.env.OWNER_EMAIL } },
       status: "authenticated",
     });
 
-    // Aqui temos um problema: o allowed é estado interno (useState) que começa em null
-    // e só vira true dentro do useEffect, que depende da chamada real à API.
-    // Para o estado atual do componente, é difícil forçar allowed === true sem refatorar.
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ allowed: true, owner: true, permissions: {} }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ albums: [] }),
+      });
 
-    // Então, para não burlar a lógica nem introduzir mocks complexos de fetch,
-    // podemos ENQUANTO ISSO limitar a cobertura a estados 1–3 acima.
-    // Quando você quiser, podemos refatorar a lógica para injetar allowed como prop
-    // em ambiente de teste, facilitando esse teste.
+    render(<AlbumPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/área administrativa/i)).toBeInTheDocument();
+    });
   });
 });

--- a/tests/api/AddPhoto.test.js
+++ b/tests/api/AddPhoto.test.js
@@ -1,0 +1,99 @@
+import handler from "../../pages/api/album/add-photo";
+import { getServerSession } from "next-auth";
+import { ddb } from "../../lib/dynamo";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("../../pages/api/auth/[...nextauth]", () => ({ authOptions: {} }));
+jest.mock("../../lib/dynamo", () => ({ ddb: { send: jest.fn() } }));
+jest.mock("@aws-sdk/lib-dynamodb", () => ({
+  GetCommand: jest.fn().mockImplementation((p) => p),
+  PutCommand: jest.fn().mockImplementation((p) => p),
+}));
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("POST /api/album/add-photo", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("retorna 405 para método não-POST", async () => {
+    const res = mockRes();
+    await handler({ method: "GET" }, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it("retorna 401 quando não há sessão autenticada", async () => {
+    getServerSession.mockResolvedValue(null);
+    const res = mockRes();
+    await handler({ method: "POST", body: {} }, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("retorna 403 quando usuário não tem canUploadPhotos", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "outro@test.com" } });
+    ddb.send.mockResolvedValueOnce({ Item: { canUploadPhotos: false } });
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { albumCode: "012025", s3Key: "albuns/012025/foto.jpg" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("retorna 403 quando DynamoDB falha na verificação de permissão", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "outro@test.com" } });
+    ddb.send.mockRejectedValueOnce(new Error("DynamoDB error"));
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { albumCode: "012025", s3Key: "albuns/012025/foto.jpg" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("retorna 400 quando albumCode está ausente", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    const res = mockRes();
+    await handler({ method: "POST", body: { s3Key: "albuns/012025/foto.jpg" } }, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("retorna 400 quando s3Key está ausente", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    const res = mockRes();
+    await handler({ method: "POST", body: { albumCode: "012025" } }, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("retorna 200 e salva metadados quando chamado pelo owner", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    ddb.send.mockResolvedValueOnce({});
+    const res = mockRes();
+    await handler(
+      {
+        method: "POST",
+        body: { albumCode: "012025", s3Key: "albuns/012025/foto.jpg", takenDate: "2025-01-15" },
+      },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it("retorna 200 quando usuário tem canUploadPhotos", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "autorizado@test.com" } });
+    ddb.send
+      .mockResolvedValueOnce({ Item: { canUploadPhotos: true } })
+      .mockResolvedValueOnce({});
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { albumCode: "012025", s3Key: "albuns/012025/foto.jpg" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/tests/api/Delete.test.js
+++ b/tests/api/Delete.test.js
@@ -1,0 +1,109 @@
+import handler from "../../pages/api/album/delete";
+import { getServerSession } from "next-auth";
+import { ddb } from "../../lib/dynamo";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("../../pages/api/auth/[...nextauth]", () => ({ authOptions: {} }));
+jest.mock("../../lib/dynamo", () => ({ ddb: { send: jest.fn() } }));
+jest.mock("@aws-sdk/lib-dynamodb", () => ({
+  GetCommand: jest.fn().mockImplementation((p) => p),
+  UpdateCommand: jest.fn().mockImplementation((p) => p),
+  QueryCommand: jest.fn().mockImplementation((p) => p),
+}));
+jest.mock("@aws-sdk/client-s3", () => ({
+  S3Client: jest.fn().mockImplementation(() => ({
+    send: jest.fn().mockResolvedValue({}),
+  })),
+  DeleteObjectCommand: jest.fn().mockImplementation((p) => p),
+}));
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("POST /api/album/delete", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("retorna 405 para método não-POST", async () => {
+    const res = mockRes();
+    await handler({ method: "GET" }, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it("retorna 401 quando não há sessão autenticada", async () => {
+    getServerSession.mockResolvedValue(null);
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { key: "albuns/012025/foto.jpg", albumCode: "012025" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("retorna 403 quando usuário não tem canDeletePhotos", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "outro@test.com" } });
+    ddb.send.mockResolvedValueOnce({ Item: { canDeletePhotos: false } });
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { key: "albuns/012025/foto.jpg", albumCode: "012025" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("retorna 403 quando DynamoDB falha na verificação de permissão", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "outro@test.com" } });
+    ddb.send.mockRejectedValueOnce(new Error("DynamoDB error"));
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { key: "albuns/012025/foto.jpg", albumCode: "012025" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("retorna 400 quando key está ausente", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    const res = mockRes();
+    await handler({ method: "POST", body: { albumCode: "012025" } }, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("retorna 400 quando albumCode está ausente", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { key: "albuns/012025/foto.jpg" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("retorna 200 quando owner deleta foto com soft-delete no DynamoDB", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    ddb.send.mockResolvedValueOnce({ Items: [] }); // QueryCommand sem itens
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { key: "albuns/012025/foto.jpg", albumCode: "012025" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it("retorna 200 quando usuário com canDeletePhotos deleta foto", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "autorizado@test.com" } });
+    ddb.send
+      .mockResolvedValueOnce({ Item: { canDeletePhotos: true } }) // whitelist check
+      .mockResolvedValueOnce({ Items: [] }); // QueryCommand
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { key: "albuns/012025/foto.jpg", albumCode: "012025" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/tests/api/UploadUrl.test.js
+++ b/tests/api/UploadUrl.test.js
@@ -1,0 +1,124 @@
+import handler from "../../pages/api/album/upload-url";
+import { getServerSession } from "next-auth";
+import { ddb } from "../../lib/dynamo";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("../../pages/api/auth/[...nextauth]", () => ({ authOptions: {} }));
+jest.mock("../../lib/dynamo", () => ({ ddb: { send: jest.fn() } }));
+jest.mock("@aws-sdk/lib-dynamodb", () => ({
+  GetCommand: jest.fn().mockImplementation((p) => p),
+}));
+jest.mock("@aws-sdk/client-s3", () => ({
+  S3Client: jest.fn().mockImplementation(() => ({})),
+  PutObjectCommand: jest.fn().mockImplementation((p) => p),
+}));
+jest.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: jest.fn(),
+}));
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("POST /api/album/upload-url", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("retorna 405 para método não-POST", async () => {
+    const res = mockRes();
+    await handler({ method: "GET" }, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it("retorna 401 quando não há sessão autenticada", async () => {
+    getServerSession.mockResolvedValue(null);
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { fileName: "foto.jpg", fileType: "image/jpeg" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("retorna 403 quando usuário não tem canUploadPhotos", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "outro@test.com" } });
+    ddb.send.mockResolvedValueOnce({ Item: { canUploadPhotos: false } });
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { fileName: "foto.jpg", fileType: "image/jpeg" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("retorna 403 quando DynamoDB falha na verificação de permissão", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "outro@test.com" } });
+    ddb.send.mockRejectedValueOnce(new Error("DynamoDB error"));
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { fileName: "foto.jpg", fileType: "image/jpeg" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("retorna 400 quando fileName está ausente", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    const res = mockRes();
+    await handler({ method: "POST", body: { fileType: "image/jpeg" } }, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("retorna 400 quando fileType está ausente", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    const res = mockRes();
+    await handler({ method: "POST", body: { fileName: "foto.jpg" } }, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("retorna 200 com uploadUrl e key quando owner faz requisição válida", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    getSignedUrl.mockResolvedValue("https://s3.mock/presigned-url");
+    const res = mockRes();
+    await handler(
+      {
+        method: "POST",
+        body: {
+          fileName: "foto.jpg",
+          fileType: "image/jpeg",
+          s3Key: "albuns/012025/foto.jpg",
+        },
+      },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploadUrl: "https://s3.mock/presigned-url",
+        key: "albuns/012025/foto.jpg",
+      })
+    );
+  });
+
+  it("retorna 200 quando usuário tem canUploadPhotos", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "autorizado@test.com" } });
+    ddb.send.mockResolvedValueOnce({ Item: { canUploadPhotos: true } });
+    getSignedUrl.mockResolvedValue("https://s3.mock/presigned-url");
+    const res = mockRes();
+    await handler(
+      {
+        method: "POST",
+        body: {
+          fileName: "foto.jpg",
+          fileType: "image/jpeg",
+          s3Key: "albuns/012025/foto.jpg",
+        },
+      },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/tests/api/WhitelistCheck.test.js
+++ b/tests/api/WhitelistCheck.test.js
@@ -1,0 +1,130 @@
+import handler from "../../pages/api/whitelist/check";
+import { getServerSession } from "next-auth";
+import { ddb } from "../../lib/dynamo";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("../../pages/api/auth/[...nextauth]", () => ({ authOptions: {} }));
+jest.mock("../../lib/dynamo", () => ({ ddb: { send: jest.fn() } }));
+jest.mock("@aws-sdk/lib-dynamodb", () => ({
+  GetCommand: jest.fn().mockImplementation((p) => p),
+}));
+jest.mock("../../lib/logger", () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+  maskEmail: jest.fn((e) => e),
+}));
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("POST /api/whitelist/check", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("retorna 405 para método não-POST", async () => {
+    const res = mockRes();
+    await handler({ method: "GET", body: {} }, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it("retorna 401 quando não há sessão autenticada", async () => {
+    getServerSession.mockResolvedValue(null);
+    const res = mockRes();
+    await handler({ method: "POST", body: { email: "alguem@test.com" } }, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("retorna 400 quando e-mail não é fornecido no body", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "alguem@test.com" } });
+    const res = mockRes();
+    await handler({ method: "POST", body: {} }, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("retorna allowed=true e owner=true para o dono sem consultar o DynamoDB", async () => {
+    getServerSession.mockResolvedValue({ user: { email: process.env.OWNER_EMAIL } });
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { email: process.env.OWNER_EMAIL } },
+      res
+    );
+    expect(ddb.send).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ allowed: true, owner: true })
+    );
+  });
+
+  it("retorna allowed=false quando e-mail não está na whitelist", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "naoexiste@test.com" } });
+    ddb.send.mockResolvedValueOnce({ Item: null });
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { email: "naoexiste@test.com" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ allowed: false, owner: false, permissions: null })
+    );
+  });
+
+  it("retorna allowed=true com permissões corretas para usuário ativo na whitelist", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "autorizado@test.com" } });
+    ddb.send.mockResolvedValueOnce({
+      Item: {
+        email: "autorizado@test.com",
+        isActive: true,
+        canViewAlbums: true,
+        canUploadPhotos: true,
+        canDeletePhotos: false,
+        canEditProfile: false,
+      },
+    });
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { email: "autorizado@test.com" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowed: true,
+        owner: false,
+        permissions: expect.objectContaining({
+          canUploadPhotos: true,
+          canDeletePhotos: false,
+        }),
+      })
+    );
+  });
+
+  it("retorna allowed=false para usuário inativo mesmo estando na whitelist", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "inativo@test.com" } });
+    ddb.send.mockResolvedValueOnce({
+      Item: { email: "inativo@test.com", isActive: false, canViewAlbums: true },
+    });
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { email: "inativo@test.com" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ allowed: false })
+    );
+  });
+
+  it("retorna 500 quando DynamoDB lança erro", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "alguem@test.com" } });
+    ddb.send.mockRejectedValueOnce(new Error("DynamoDB timeout"));
+    const res = mockRes();
+    await handler(
+      { method: "POST", body: { email: "alguem@test.com" } },
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/tests/lib/Photos.test.js
+++ b/tests/lib/Photos.test.js
@@ -1,0 +1,89 @@
+import { listPhotosByAlbum } from "../../lib/photos";
+import { ddb } from "../../lib/dynamo";
+
+jest.mock("../../lib/dynamo", () => ({ ddb: { send: jest.fn() } }));
+jest.mock("@aws-sdk/lib-dynamodb", () => ({
+  QueryCommand: jest.fn().mockImplementation((p) => p),
+}));
+jest.mock("../../lib/logger", () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+describe("listPhotosByAlbum", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("retorna apenas fotos ativas (deletedAt null) do álbum", async () => {
+    ddb.send.mockResolvedValueOnce({
+      Items: [
+        { albumCode: "012025", photoKey: "p1", s3Key: "foto1.jpg", deletedAt: null },
+        { albumCode: "012025", photoKey: "p2", s3Key: "foto2.jpg", deletedAt: null },
+      ],
+      LastEvaluatedKey: undefined,
+    });
+
+    const result = await listPhotosByAlbum("012025");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].s3Key).toBe("foto1.jpg");
+  });
+
+  it("filtra fotos com deletedAt preenchido (soft delete)", async () => {
+    ddb.send.mockResolvedValueOnce({
+      Items: [
+        { albumCode: "012025", photoKey: "p1", s3Key: "ativa.jpg", deletedAt: null },
+        { albumCode: "012025", photoKey: "p2", s3Key: "deletada.jpg", deletedAt: "2025-03-01T00:00:00Z" },
+        { albumCode: "012025", photoKey: "p3", s3Key: "ativa2.jpg", deletedAt: null },
+      ],
+      LastEvaluatedKey: undefined,
+    });
+
+    const result = await listPhotosByAlbum("012025");
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.s3Key)).toEqual(["ativa.jpg", "ativa2.jpg"]);
+  });
+
+  it("percorre múltiplas páginas retornando todos os itens (paginação)", async () => {
+    ddb.send
+      .mockResolvedValueOnce({
+        Items: [{ albumCode: "012025", photoKey: "p1", s3Key: "foto1.jpg", deletedAt: null }],
+        LastEvaluatedKey: { albumCode: "012025", photoKey: "p1" },
+      })
+      .mockResolvedValueOnce({
+        Items: [{ albumCode: "012025", photoKey: "p2", s3Key: "foto2.jpg", deletedAt: null }],
+        LastEvaluatedKey: undefined,
+      });
+
+    const result = await listPhotosByAlbum("012025");
+
+    expect(ddb.send).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.s3Key)).toEqual(["foto1.jpg", "foto2.jpg"]);
+  });
+
+  it("retorna array vazio quando álbum não tem fotos", async () => {
+    ddb.send.mockResolvedValueOnce({
+      Items: [],
+      LastEvaluatedKey: undefined,
+    });
+
+    const result = await listPhotosByAlbum("012025");
+
+    expect(result).toHaveLength(0);
+    expect(result).toEqual([]);
+  });
+
+  it("retorna array vazio quando todas as fotos do álbum foram deletadas", async () => {
+    ddb.send.mockResolvedValueOnce({
+      Items: [
+        { albumCode: "012025", photoKey: "p1", s3Key: "foto1.jpg", deletedAt: "2025-01-01T00:00:00Z" },
+        { albumCode: "012025", photoKey: "p2", s3Key: "foto2.jpg", deletedAt: "2025-01-02T00:00:00Z" },
+      ],
+      LastEvaluatedKey: undefined,
+    });
+
+    const result = await listPhotosByAlbum("012025");
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/tests/security/NoHardcoded.test.js
+++ b/tests/security/NoHardcoded.test.js
@@ -1,0 +1,76 @@
+import fs from "fs";
+import path from "path";
+
+const ROOT = path.resolve(process.cwd());
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+function scanDir(dir, ext = ".js") {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...scanDir(full, ext));
+    else if (entry.name.endsWith(ext)) results.push(full);
+  }
+  return results;
+}
+
+describe("Segurança — Sem valores hardcoded no setup e arquivos de teste", () => {
+  test("jest.setup.js não contém atribuições hardcoded de process.env com fallback", () => {
+    const content = readFile(path.join(ROOT, "jest.setup.js"));
+    // Detecta padrão: process.env.QUALQUER_COISA = ... || "valor"
+    const hardcodedFallback = /process\.env\.\w+\s*=\s*.+\|\|/;
+    expect(hardcodedFallback.test(content)).toBe(false);
+  });
+
+  test("jest.setup.js não contém endereços de e-mail", () => {
+    const content = readFile(path.join(ROOT, "jest.setup.js"));
+    const emailPattern = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
+    expect(emailPattern.test(content)).toBe(false);
+  });
+
+  test("jest.setup.js não contém padrão de AWS Access Key (AKIA...)", () => {
+    const content = readFile(path.join(ROOT, "jest.setup.js"));
+    expect(/AKIA[A-Z0-9]{16}/.test(content)).toBe(false);
+  });
+
+  test(".env.test existe para fornecer vars de ambiente nos testes", () => {
+    expect(fs.existsSync(path.join(ROOT, ".env.test"))).toBe(true);
+  });
+
+  test(".env.test não contém AWS Access Key real (AKIA...)", () => {
+    const content = readFile(path.join(ROOT, ".env.test"));
+    expect(/AKIA[A-Z0-9]{16}/.test(content)).toBe(false);
+  });
+
+  test(".env.test não contém e-mail pessoal real (domínios conhecidos)", () => {
+    const content = readFile(path.join(ROOT, ".env.test"));
+    // Bloqueia domínios de e-mail pessoal reais — valores de teste devem usar @test.com
+    const realEmailDomains = /@(gmail|hotmail|outlook|yahoo|live|icloud)\.com/i;
+    expect(realEmailDomains.test(content)).toBe(false);
+  });
+
+  test("nenhum arquivo de teste contém e-mail com domínio pessoal hardcoded", () => {
+    const realEmailDomains = /@(gmail|hotmail|outlook|yahoo|live|icloud)\.com/i;
+    const testFiles = scanDir(path.join(ROOT, "tests"));
+    const violations = testFiles.filter((file) =>
+      realEmailDomains.test(readFile(file))
+    );
+    expect(violations).toEqual([]);
+  });
+
+  test("nenhum arquivo de teste (fora da pasta security) contém atribuição hardcoded de process.env com fallback", () => {
+    const hardcodedFallback = /process\.env\.\w+\s*=\s*.+\|\|/;
+    const allFiles = scanDir(path.join(ROOT, "tests"));
+    // Exclui os próprios arquivos de segurança para evitar falso positivo com o padrão de regex
+    const testFiles = allFiles.filter(
+      (f) => !f.includes(path.join("tests", "security"))
+    );
+    const violations = testFiles.filter((file) =>
+      hardcodedFallback.test(readFile(file))
+    );
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/security/NoSecrets.test.js
+++ b/tests/security/NoSecrets.test.js
@@ -1,0 +1,99 @@
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+
+const ROOT = path.resolve(__dirname, "../..");
+
+function getAllJsFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (
+      entry.isDirectory() &&
+      !["node_modules", ".next", ".git"].includes(entry.name)
+    ) {
+      results.push(...getAllJsFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".js")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+const apiFiles = getAllJsFiles(path.join(ROOT, "pages/api"));
+const sourceFiles = [
+  ...getAllJsFiles(path.join(ROOT, "pages")),
+  ...getAllJsFiles(path.join(ROOT, "lib")),
+  ...getAllJsFiles(path.join(ROOT, "components")),
+];
+
+describe("Segurança — Sem segredos hardcoded", () => {
+  it("nenhum e-mail de owner hardcoded nos arquivos de API (deve usar process.env.OWNER_EMAIL)", () => {
+    const ownerEmail = process.env.OWNER_EMAIL;
+    if (!ownerEmail) return;
+
+    for (const file of apiFiles) {
+      const content = fs.readFileSync(file, "utf-8");
+      expect(content).not.toContain(ownerEmail);
+    }
+  });
+
+  it("nenhuma AWS Access Key ID hardcoded nos arquivos fonte", () => {
+    const AWS_KEY_PATTERN = /AKIA[A-Z0-9]{16}/;
+    for (const file of sourceFiles) {
+      const content = fs.readFileSync(file, "utf-8");
+      expect(AWS_KEY_PATTERN.test(content)).toBe(false);
+    }
+  });
+
+  it(".env.local está coberto pelo .gitignore", () => {
+    const gitignore = fs.readFileSync(path.join(ROOT, ".gitignore"), "utf-8");
+    expect(gitignore).toMatch(/\.env\*\.local|\.env\.local/);
+  });
+
+  it(".env está coberto pelo .gitignore", () => {
+    const gitignore = fs.readFileSync(path.join(ROOT, ".gitignore"), "utf-8");
+    expect(gitignore).toMatch(/^\.env$/m);
+  });
+
+  it(".vercel está coberto pelo .gitignore", () => {
+    const gitignore = fs.readFileSync(path.join(ROOT, ".gitignore"), "utf-8");
+    expect(gitignore).toContain(".vercel");
+  });
+
+  it("node_modules está coberto pelo .gitignore", () => {
+    const gitignore = fs.readFileSync(path.join(ROOT, ".gitignore"), "utf-8");
+    expect(gitignore).toContain("node_modules");
+  });
+
+  it(".env.local não está rastreado pelo git", () => {
+    const tracked = execSync("git ls-files .env.local", { cwd: ROOT })
+      .toString()
+      .trim();
+    expect(tracked).toBe("");
+  });
+
+  it(".vercel não está rastreado pelo git", () => {
+    const tracked = execSync("git ls-files .vercel", { cwd: ROOT })
+      .toString()
+      .trim();
+    expect(tracked).toBe("");
+  });
+
+  it("variáveis sensíveis não usam prefixo NEXT_PUBLIC_", () => {
+    const forbidden = [
+      "NEXT_PUBLIC_AWS_SECRET",
+      "NEXT_PUBLIC_AWS_ACCESS_KEY",
+      "NEXT_PUBLIC_GOOGLE_CLIENT_SECRET",
+      "NEXT_PUBLIC_NEXTAUTH_SECRET",
+      "NEXT_PUBLIC_OWNER_EMAIL",
+    ];
+    for (const file of sourceFiles) {
+      const content = fs.readFileSync(file, "utf-8");
+      for (const key of forbidden) {
+        expect(content).not.toContain(key);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Resumo

- **Segurança nas APIs**: `add-photo`, `upload-url` e `delete` agora exigem sessão válida (401) e verificam permissões granulares (`canUploadPhotos` / `canDeletePhotos`) via DynamoDB — antes apenas o owner tinha controle
- **Sem hardcode**: e-mail do owner removido do código e centralizado em `process.env.OWNER_EMAIL` em todos os handlers
- **Paginação completa**: `whitelist/list` agora percorre todas as páginas via `LastEvaluatedKey` em vez de retornar apenas o primeiro scan
- **Limpeza**: dead code removido de `list-albums`, prefixo S3 corrigido em `list`

## Testes — 67 passando

- `tests/api/`: AddPhoto, UploadUrl, Delete, WhitelistCheck (8 casos cada)
- `tests/lib/Photos`: paginação e filtragem de soft-delete
- `tests/security/NoSecrets`: sem segredos hardcoded, .gitignore correto, sem `NEXT_PUBLIC_` em vars sensíveis
- `tests/AlbumDetailPage`, `AlbumPage`: estados de UI e painel admin

## Plano de testes

- [ ] Verificar 67/67 testes passando localmente com `npx jest`
- [ ] Testar upload de foto como owner em produção
- [ ] Testar upload como usuário com `canUploadPhotos=true`
- [ ] Confirmar que usuário sem permissão recebe 403
- [ ] Confirmar que `whitelist/list` retorna todos os registros (>= 1 MB)