### PR TITLE
docs: atualiza README e ROADMAP, cria CHANGELOG e CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# CHANGELOG
+
+Todas as mudanças notáveis deste projeto são documentadas aqui.
+
+Formato baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
+
+---
+
+## [0.3.0] – 2026-04-04
+
+### Segurança
+- Controle de acesso granular nas APIs `add-photo`, `upload-url` e `delete`: autenticação obrigatória (401) e verificação de permissões granulares (`canUploadPhotos`, `canDeletePhotos`) via DynamoDB
+- `OWNER_EMAIL` centralizado em `process.env.OWNER_EMAIL` em todos os handlers — nenhum e-mail hardcoded no código
+
+### Corrigido
+- `whitelist/list`: substituído scan único por loop de paginação com `LastEvaluatedKey` — garante retorno de todos os registros independente do volume
+- `list-albums`: removido dead code inalcançável no bloco `catch`
+- `list`: corrigido prefixo S3 de `album/` para `albuns/`
+
+### Testes
+- 75 testes passando em 14 suites
+- Novos testes de API: `AddPhoto`, `UploadUrl`, `Delete`, `WhitelistCheck` (8 casos cada)
+- Novos testes de lib: `listPhotosByAlbum` com paginação e soft delete
+- Novos testes de segurança: `NoSecrets` e `NoHardcoded`
+- `.env.test` criado com valores fake — sem hardcode em `jest.setup.js`
+
+---
+
+## [0.2.0] – 2026-03-03
+
+### Adicionado
+- Matriz de permissões granulares: `canViewAlbums`, `canUploadPhotos`, `canDeletePhotos`, `canEditProfile`, `isActive`
+- Painel administrativo para o owner
+- Documentação de permissões (`docs/PERMISSIONS.md`, `docs/ADMIN_PAINEL.md`)
+- README.md reestruturado com roadmap e guia de contribuição
+- CONTRIBUTING.md
+- ROADMAP.md v3.0
+
+### Corrigido
+- Declaração duplicada de `isOwner` em `albumCode`
+- Paginação no DynamoDB Scan/Query
+
+### Segurança
+- Security headers HTTP reforçados (CSP, HSTS, X-Frame-Options)
+- Rate limiting nas rotas de autenticação
+
+---
+
+## [0.1.0] – 2026-01-01
+
+### Adicionado
+- Autenticação via Google OAuth (NextAuth v4)
+- Whitelist de acesso armazenada no DynamoDB
+- Upload de fotos para AWS S3 com presigned URLs
+- Galeria de álbuns integrada ao DynamoDB
+- Portfólio visual: HeroSection, AboutSection, SkillsSection, StatsSection, ProjectsSection
+- Refatoração para componentes isolados
+- Primeiros testes com Jest + React Testing Library
+- AWS SDK v3 (DynamoDB + S3)
+- Deploy contínuo na Vercel
+
+---
+
+[0.3.0]: https://github.com/patocg/firstproject/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/patocg/firstproject/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/patocg/firstproject/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+Guia para o Claude Code trabalhar neste projeto.
+
+---
+
+## Projeto
+
+**firstproject** — portfólio pessoal + álbum de família privado.
+Deploy: https://jnths.com.br
+Stack: Next.js 16 + React 19, AWS S3 + DynamoDB, NextAuth v4 + Google OAuth, Vercel.
+
+---
+
+## Setup local
+
+```bash
+npm install
+vercel env pull .env.local   # requer: vercel link (já configurado)
+npm run dev
+```
+
+As variáveis de ambiente vivem na Vercel. Nunca crie `.env.local` manualmente — use sempre `vercel env pull`.
+
+---
+
+## Testes
+
+```bash
+npm test          # todos os testes
+npm test -- --watch   # modo watch
+```
+
+- 75 testes, 14 suites — todos devem passar antes de qualquer commit
+- `.env.test` fornece valores fake para `NODE_ENV=test` (Next.js não carrega `.env.local` em modo de teste)
+- Nunca adicione fallbacks hardcoded em `jest.setup.js` — o `NoHardcoded.test.js` vai rejeitar
+
+---
+
+## Estrutura
+
+```
+pages/api/        → API Routes (handlers Next.js)
+pages/api/album/  → add-photo, delete, list, list-albums, upload-url
+pages/api/auth/   → [...nextauth].js
+pages/api/whitelist/ → check, list
+lib/              → dynamo.js, photos.js, logger.js
+components/       → componentes de UI reutilizáveis
+tests/api/        → testes das API routes
+tests/lib/        → testes das funções de lib
+tests/security/   → NoSecrets.test.js, NoHardcoded.test.js
+```
+
+---
+
+## Convenções obrigatórias
+
+### Variáveis de ambiente
+- Todas as vars sensíveis vivem na Vercel e são puxadas via `vercel env pull`
+- `OWNER_EMAIL` deve ser sempre lido via `process.env.OWNER_EMAIL` — nunca hardcoded
+- Nunca use prefixo `NEXT_PUBLIC_` em variáveis sensíveis (AWS keys, emails, secrets)
+
+### Commits
+Seguir [Conventional Commits](https://www.conventionalcommits.org):
+```
+feat(escopo): descrição
+fix(escopo): descrição
+test(escopo): descrição
+docs(escopo): descrição
+refactor(escopo): descrição
+chore(escopo): descrição
+```
+Commits genéricos como "update" ou "fix bug" não são aceitos.
+
+### Branches
+```
+main       → produção (push direto bloqueado)
+develop    → homologação
+feature/*  → novas funcionalidades
+fix/*      → correções
+refactor/* → melhorias estruturais
+hotfix/*   → correções críticas
+```
+PRs sempre de `feature/*` ou `develop` → `main`. Nunca push direto na `main`.
+
+---
+
+## O que nunca fazer
+
+- Hardcodar e-mails, AWS keys ou qualquer segredo no código
+- Commitar `.env.local`, `.env`, `.vercel/` (cobertos pelo `.gitignore`)
+- Usar `NEXT_PUBLIC_` em variáveis sensíveis
+- Adicionar fallbacks com valor real em `jest.setup.js` (use `.env.test`)
+- Push direto na `main`
+- Remover ou enfraquecer checagens de autenticação/autorização existentes
+
+---
+
+## Controle de acesso
+
+Toda API que manipula fotos ou dados privados deve:
+1. Verificar sessão via `getServerSession` → retornar 401 se ausente
+2. Se não for owner (`email !== OWNER_EMAIL`), consultar o DynamoDB com `GetCommand` na tabela `DYNAMO_TABLE_WHITELIST`
+3. Verificar a permissão específica (`canUploadPhotos`, `canDeletePhotos` etc.) → retornar 403 se ausente
+
+---
+
+## Issues abertas relevantes
+
+- **#8** — CI/CD com GitHub Actions (`lint → test → build → security scan`)
+- **#10** — Commitlint + Husky
+
+---
+
+## Documentação
+
+- `README.md` — visão geral e instruções de uso
+- `ROADMAP.md` — fases de evolução e status atual
+- `CHANGELOG.md` — histórico de mudanças por versão
+- `CONTRIBUTING.md` — guia para contribuições
+- `docs/PERMISSIONS.md` — matriz de permissões detalhada
+- `docs/ADMIN_PAINEL.md` — documentação do painel admin

--- a/README.md
+++ b/README.md
@@ -4,15 +4,12 @@ Aplicação web desenvolvida com Next.js, integrando AWS (S3 + DynamoDB), autent
 
 Este projeto evoluiu de um portfólio visual para um laboratório de engenharia focado em arquitetura, segurança, DevOps e governança de código.
 
-Deploy em produção:
-https://jnths.com.br
-
-Repositório:
-https://github.com/patocg/firstproject
+Deploy em produção: https://jnths.com.br
+Repositório: https://github.com/patocg/firstproject
 
 ---
 
-# 1. Objetivo do Projeto
+## 1. Objetivo do Projeto
 
 O firstproject não é apenas uma vitrine visual.
 
@@ -20,8 +17,8 @@ Ele foi estruturado para demonstrar:
 
 - Arquitetura escalável
 - Integração com serviços cloud
-- Controle de acesso baseado em regras
-- Hardening básico de segurança
+- Controle de acesso baseado em regras granulares
+- Hardening de segurança aplicado
 - Governança de código
 - Preparação para CI/CD e observabilidade
 
@@ -29,206 +26,214 @@ Ele foi estruturado para demonstrar:
 
 ---
 
-# 2. Stack Tecnológica
+## 2. Stack Tecnológica
 
-Frontend:
-- Next.js
-- React
+**Frontend**
+- Next.js 16 + React 19
 
-Backend / API:
+**Backend / API**
 - Next.js API Routes
 - AWS SDK v3
 
-Cloud:
+**Cloud**
 - AWS S3 (armazenamento de assets)
-- AWS DynamoDB (controle de acesso / whitelist)
+- AWS DynamoDB (whitelist, fotos, logs de acesso negado)
 
-Autenticação:
-- NextAuth
+**Autenticação**
+- NextAuth v4
 - Google OAuth
 
-DevOps:
-- Vercel (deploy)
+**DevOps**
+- Vercel (deploy + env vars)
 - GitHub (versionamento)
-- Jest (testes)
+- Jest + React Testing Library (testes)
 - ESLint + Prettier
 
 ---
 
-# 3. Arquitetura
+## 3. Arquitetura
 
-Estrutura atual:
-- `components/` → Componentes reutilizáveis
-- `lib/` → Camada de acesso a dados e utilitários
-- `pages/` → Rotas e API handlers
-- `public/` → Assets estáticos
-- `tests/` → Testes automatizados
-- `docs/` → Documentação técnica`
-
+```
+components/   → Componentes reutilizáveis
+lib/          → Camada de acesso a dados e utilitários
+pages/        → Rotas e API handlers
+public/       → Assets estáticos
+tests/        → Testes automatizados
+docs/         → Documentação técnica
+```
 
 Separação de responsabilidades:
-
 - UI desacoplada da lógica
-- APIs isoladas
+- APIs isoladas por domínio
 - Acesso a dados centralizado em `lib/`
 - Regras de autorização documentadas formalmente
 
 ---
 
-# 4. Controle de Acesso
+## 4. Controle de Acesso
 
 Sistema baseado em whitelist armazenada no DynamoDB.
 
-Regras principais:
+Permissões granulares por usuário:
 
-- Usuário autenticado via Google
-- Verificação de status ativo
-- Permissão específica para visualização de álbuns
-- OWNER_EMAIL definido por variável de ambiente
+| Permissão | Descrição |
+|---|---|
+| `isActive` | Usuário ativo na whitelist |
+| `canViewAlbums` | Acesso à galeria de fotos |
+| `canUploadPhotos` | Upload de novas fotos |
+| `canDeletePhotos` | Remoção de fotos (soft delete) |
+| `canEditProfile` | Edição de perfil |
+
+O `OWNER_EMAIL` é definido exclusivamente via variável de ambiente — nunca hardcoded no código.
 
 Documentação completa:
-- docs/PERMISSIONS.md
-- docs/ADMIN_PAINEL.md
+- `docs/PERMISSIONS.md`
+- `docs/ADMIN_PAINEL.md`
 
 ---
 
-# 5. Segurança Implementada
+## 5. Segurança Implementada
 
-- Security headers HTTP
+- Security headers HTTP (CSP, HSTS, X-Frame-Options)
 - Rate limiting nas rotas de API
 - Mascaramento de dados sensíveis em logs
-- Separação por ambiente via variáveis
-- Remoção de console logs em produção
-- Logging estruturado
+- Separação por ambiente via variáveis de ambiente (Vercel)
+- Controle de acesso granular por permissão no DynamoDB
+- Nenhum segredo hardcoded — verificado por testes automatizados
+- `.env.local` nunca versionado — gerado sob demanda via `vercel env pull`
 
 Próximas evoluções planejadas:
 - CSP mais restritivo
-- Monitoramento de vulnerabilidades automatizado
-- Observabilidade com logs persistentes
+- Monitoramento de vulnerabilidades automatizado (Dependabot)
+- Observabilidade com logs persistentes (Sentry / Pino)
 
 ---
 
-# 6. Testes
+## 6. Testes
 
-Executar testes:
-- `npm test`
+```bash
+npm test
+```
 
-Meta de cobertura:
-70% (em evolução para 80%)
+Estado atual: **75 testes passando em 14 suites**
 
-Inclui:
-- Testes unitários de componentes críticos
-- Testes de integração de APIs
+| Suite | Cobertura |
+|---|---|
+| Componentes UI | HeroSection, AboutSection, SkillsSection, StatsSection, ProjectsSection, AlbumPage, AlbumDetailPage |
+| APIs | add-photo, upload-url, delete, whitelist/check |
+| Lib | listPhotosByAlbum (paginação + soft delete) |
+| Segurança | NoSecrets, NoHardcoded |
 
----
-
-# 7. Desenvolvimento Local
-
-Instalação:
-- `npm istall`
-
-Rodar em ambiente de desenvolvimento:
-- `npm run dev`
-
-
-Build para produção:
-- `npm run build`
-
+Os testes de segurança garantem automaticamente:
+- Nenhum e-mail ou credencial hardcoded no código
+- `.gitignore` cobrindo todos os arquivos sensíveis
+- Sem uso de `NEXT_PUBLIC_` em variáveis sensíveis
 
 ---
 
-# 8. Workflow de Branches
+## 7. Desenvolvimento Local
 
-Modelo adotado:
+**Instalação:**
+```bash
+npm install
+```
 
-- main → Produção
-- develop → Homologação
-- feature/* → Novas funcionalidades
-- fix/* → Correções
-- refactor/* → Melhorias estruturais
+**Variáveis de ambiente** (requer Vercel CLI):
+```bash
+vercel env pull .env.local
+```
 
-Commits seguem padrão Conventional Commits.
+**Rodar em desenvolvimento:**
+```bash
+npm run dev
+```
 
-Exemplo:
-- `feat(auth)`: implementa validação de whitelist
-- `fix(api)`: corrige tratamento de erro no S3
-- `refactor(logging)`: remove console.log em produção
-
-
----
-
-# 9. CI/CD e Automação
-
-Pipeline em evolução para incluir:
-
-- Lint obrigatório
-- Testes automatizados
-- Build validado
-- Security scan
-- Deploy automático em main
-
-Objetivo:
-Nenhum merge com falha de pipeline.
+**Build para produção:**
+```bash
+npm run build
+```
 
 ---
 
-# 10. Roadmap
+## 8. Workflow de Branches
 
-O roadmap estratégico completo está disponível em:
+| Branch | Propósito |
+|---|---|
+| `main` | Produção |
+| `develop` | Homologação |
+| `feature/*` | Novas funcionalidades |
+| `fix/*` | Correções de bugs |
+| `refactor/*` | Melhorias estruturais |
+| `hotfix/*` | Correções críticas em produção |
 
-ROADMAP.md
+Commits seguem o padrão [Conventional Commits](https://www.conventionalcommits.org):
+
+```
+feat(auth): implementa validação de whitelist
+fix(api): corrige tratamento de erro no S3
+test(security): adiciona verificação de hardcode
+```
+
+---
+
+## 9. CI/CD e Automação
+
+Pipeline planejado (GitHub Actions — issue #8):
+
+```
+lint → test → build → security scan → deploy
+```
+
+Objetivo: nenhum merge com falha de pipeline.
+
+---
+
+## 10. Roadmap
+
+O roadmap estratégico completo está disponível em [ROADMAP.md](ROADMAP.md).
 
 Foco atual:
-
-1. Aumento de cobertura de testes
-2. CI/CD completo
+1. CI/CD completo com GitHub Actions
+2. Commitlint + Husky
 3. TypeScript progressivo
 4. Modularização por domínio
 5. Observabilidade e monitoramento
 
-Meta de maturidade técnica: 8.5+/10
+---
+
+## 11. Changelog
+
+Histórico de mudanças disponível em [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
-# 11. Performance e Qualidade
+## 12. Performance e Qualidade
 
-Metas de qualidade:
+Metas Lighthouse:
 
-- Lighthouse Performance > 90
-- Accessibility > 95
-- Best Practices > 95
-- SEO > 90
-
----
-
-# 12. Licença
-
-Licença a ser definida (recomendado: MIT).
+| Métrica | Meta |
+|---|---|
+| Performance | > 90 |
+| Accessibility | > 95 |
+| Best Practices | > 95 |
+| SEO | > 90 |
 
 ---
 
-# 13. Posicionamento Técnico
+## 13. Licença
+
+MIT (a ser formalizada).
+
+---
+
+## 14. Posicionamento Técnico
 
 Este projeto demonstra:
 
-- Capacidade de integrar frontend e backend
-- Experiência com AWS
-- Mentalidade DevOps
-- Governança de código
-- Evolução arquitetural contínua
-- Preocupação com segurança
+- Capacidade de integrar frontend e backend em ambiente cloud real
+- Experiência prática com AWS (S3 + DynamoDB)
+- Mentalidade DevOps e segurança por padrão
+- Governança de código com testes automatizados e sem segredos no repositório
+- Evolução arquitetural contínua e disciplinada
 
-Não é apenas um site.
-É um estudo contínuo de engenharia aplicada.
-
----
-
-# 14. Próxima Revisão Técnica
-
-Revisão estratégica prevista para:
-03/04/2026
-
-Objetivo:
-Avaliar evolução da cobertura de testes, pipeline CI/CD e hardening.
-
----
+Não é apenas um site. É um estudo contínuo de engenharia aplicada.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,20 +1,19 @@
-# FIRSTPROJECT – ROADMAP ESTRATÉGICO v3.0
-Atualizado em: 03/03/2026
-Autor: jonathas Cunha (Cursando Engenharia de Software - 7° SEM)
+# FIRSTPROJECT – ROADMAP ESTRATÉGICO v4.0
+Atualizado em: 04/04/2026
+Autor: Jonathas Cunha (Cursando Engenharia de Software - 7° sem.)
 
 ---
 
-# 1. VISÃO ESTRATÉGICA
+## 1. Visão Estratégica
 
-Objetivo do projeto:
 Consolidar o firstproject como um portfólio técnico de alto nível, com arquitetura escalável, segurança robusta, automação completa e governança madura.
 
-Meta de maturidade:
-Elevar o projeto do nível atual (~6.8/10) para 8.5+ em critérios profissionais de engenharia.
+**Score de maturidade atual: ~7.5/10**
+Meta: 8.5+/10
 
 ---
 
-# 2. EIXOS DE EVOLUÇÃO
+## 2. Eixos de Evolução
 
 1. Confiabilidade (Testes + CI)
 2. Governança (Padrões + Workflow)
@@ -25,154 +24,146 @@ Elevar o projeto do nível atual (~6.8/10) para 8.5+ em critérios profissionais
 
 ---
 
-# 3. FASE 1 – ESTABILIZAÇÃO (2–3 semanas)
+## 3. Fase 1 – Estabilização
 
-## 3.1 Testes Automatizados (Prioridade Crítica)
+### 3.1 Testes Automatizados — CONCLUÍDO
 
-- Expandir testes unitários (componentes críticos)
-- Testes de integração nas APIs
-- Cobertura mínima obrigatória: 75%
-- Adicionar relatório de coverage no CI
-- Fail build se coverage < 70%
+- [x] Testes unitários de componentes críticos
+- [x] Testes de integração nas APIs (add-photo, upload-url, delete, whitelist/check)
+- [x] Testes de segurança (NoSecrets, NoHardcoded)
+- [x] Testes de lib (listPhotosByAlbum com paginação e soft delete)
+- [x] 75 testes passando em 14 suites
+- [x] `.env.test` com valores fake — sem hardcode no código
+- [ ] Relatório de coverage no CI
+- [ ] Fail build se coverage < 70%
 
-Critério de aceite:
-Pipeline bloqueia merge se testes falharem.
-
----
-
-## 3.2 CI Completo (GitHub Actions)
+### 3.2 CI Completo (GitHub Actions) — PENDENTE (issue #8)
 
 Pipeline obrigatório:
-
+```
 lint → test → build → security scan
+```
 
-Ferramentas:
+Ferramentas planejadas:
 - ESLint
-- Prettier
 - Jest
 - npm audit
 - Dependabot
 
-Critério de aceite:
-PR não pode ser mergeado se pipeline falhar.
+Critério de aceite: PR não pode ser mergeado se pipeline falhar.
+
+### 3.3 Padronização de Commits — PENDENTE (issue #10)
+
+- [ ] Commitlint
+- [ ] Husky (pre-commit e commit-msg)
+
+Conventional Commits já é adotado — falta automação da validação.
 
 ---
 
-## 3.3 Padronização de Commits
+## 4. Fase 2 – Arquitetura e Banco
 
-- Commitlint
-- Husky (pre-commit e commit-msg)
-- Conventional Commits obrigatório
-
----
-
-# 4. FASE 2 – ARQUITETURA E BANCO (3–4 semanas)
-
-## 4.1 Estrutura por Domínio
+### 4.1 Estrutura por Domínio
 
 Migrar de estrutura técnica para estrutura por feature:
 
+```
 /features
   /auth
   /albums
   /admin
   /api
+```
 
-Separação clara:
-- domain
-- services
-- infra
-- presentation
+Separação clara: domain / services / infra / presentation.
 
----
-
-## 4.2 Banco de Dados Estruturado
+### 4.2 Banco de Dados Estruturado
 
 Atualmente: DynamoDB + S3
 
-Evolução recomendada:
+Evolução planejada:
 - Definir padrão definitivo (manter NoSQL ou migrar para PostgreSQL)
 - Implementar migrations formais
-- Separar ambientes:
-  - dev
-  - staging
-  - production
+- Separar ambientes: dev / staging / production
+
+### 4.3 TypeScript Progressivo
+
+- [ ] Converter arquivos críticos primeiro
+- [ ] Tipar API responses
+- [ ] Tipar modelos de dados
+- [ ] Ativar strict mode
 
 ---
 
-## 4.3 TypeScript Progressivo
+## 5. Fase 3 – Segurança Avançada
 
-- Converter arquivos críticos primeiro
-- Tipar API responses
-- Tipar modelos de dados
-- Ativar strict mode
+### 5.1 Hardening — PARCIALMENTE CONCLUÍDO
 
----
+- [x] Controle de acesso granular por permissão (canUploadPhotos, canDeletePhotos)
+- [x] OWNER_EMAIL via variável de ambiente
+- [x] Testes automatizados contra hardcode e vazamento de segredos
+- [x] Security headers HTTP
+- [x] Rate limiting nas APIs
+- [ ] CSP estrito
+- [ ] Sanitização de inputs
+- [ ] Rate limit granular por endpoint (deferred — issue aberta)
+- [ ] Logs estruturados persistentes (Pino ou Winston)
 
-# 5. FASE 3 – SEGURANÇA AVANÇADA (2–3 semanas)
+### 5.2 Monitoramento
 
-## 5.1 Hardening
-
-- CSP estrito
-- Sanitização de inputs
-- Rate limit granular por endpoint
-- Logs estruturados (Pino ou Winston)
-- Masking obrigatório de dados sensíveis
-
----
-
-## 5.2 Monitoramento
-
-- Sentry para erros
-- Vercel Analytics
-- Uptime monitor
-- Logs estruturados persistentes
+- [ ] Sentry para erros
+- [ ] Vercel Analytics
+- [ ] Uptime monitor
 
 ---
 
-# 6. FASE 4 – EXPERIÊNCIA DE CONTRIBUIÇÃO
+## 6. Fase 4 – Experiência de Contribuição — PARCIALMENTE CONCLUÍDO
 
-- CONTRIBUTING.md completo
-- CODE_OF_CONDUCT.md
-- LICENSE (MIT)
-- Templates de Issue e PR
-- Roadmap público atualizado
+- [x] README.md completo
+- [x] CONTRIBUTING.md
+- [x] ROADMAP.md
+- [x] CHANGELOG.md
+- [x] CLAUDE.md
+- [ ] CODE_OF_CONDUCT.md
+- [ ] LICENSE (MIT formal)
+- [ ] Templates de Issue e PR no GitHub
 
 ---
 
-# 7. FASE 5 – QUALIDADE VISÍVEL
+## 7. Fase 5 – Qualidade Visível
 
-Adicionar badges no README:
+Badges no README:
 
-- Build passing
-- Coverage
-- License
-- Last commit
-- Deploy status
+- [ ] Build passing (GitHub Actions)
+- [ ] Coverage
+- [ ] License
+- [ ] Last commit
+- [ ] Deploy status (Vercel)
 
 Meta Lighthouse:
-Performance > 90
-Accessibility > 95
-Best Practices > 95
-SEO > 90
+
+| Métrica | Meta |
+|---|---|
+| Performance | > 90 |
+| Accessibility | > 95 |
+| Best Practices | > 95 |
+| SEO | > 90 |
 
 ---
 
-# 8. MÉTRICAS DE MATURIDADE
+## 8. Métricas de Maturidade
 
-Objetivo final:
-
-| Dimensão | Meta |
-|----------|------|
-| Testes | 80% coverage |
-| CI/CD | 100% automatizado |
-| Segurança | Zero high vulnerabilities |
-| Documentação | 100% dos fluxos críticos documentados |
-| Tipagem | 80% do projeto em TypeScript |
+| Dimensão | Estado atual | Meta |
+|---|---|---|
+| Testes | 75 testes, ~14 suites | 80% coverage |
+| CI/CD | Pendente | 100% automatizado |
+| Segurança | Permissões granulares, sem hardcode | Zero high vulnerabilities |
+| Documentação | README, ROADMAP, CHANGELOG, CLAUDE.md | 100% dos fluxos críticos |
+| Tipagem | JavaScript | 80% em TypeScript |
 
 ---
 
-# 9. VISÃO DE LONGO PRAZO
+## 9. Visão de Longo Prazo
 
 - Transformar projeto em referência técnica pública
 - Publicar artigos técnicos baseados nele
@@ -181,10 +172,9 @@ Objetivo final:
 
 ---
 
-# 10. CONCLUSÃO
+## 10. Conclusão
 
 O projeto já demonstra maturidade crescente.
-O foco agora não é adicionar features.
-É consolidar engenharia.
+O foco agora não é adicionar features — é consolidar engenharia.
 
-Disciplina técnica agora garantirá minha liberdade no futuro.
+Disciplina técnica agora garantirá liberdade no futuro.


### PR DESCRIPTION
## Resumo

- **README.md**: corrigido typo em `npm install`, seção de testes atualizada (75 testes, 14 suites, testes de segurança), permissões granulares documentadas em tabela, seção de revisão com data expirada removida, referências ao CHANGELOG e ROADMAP adicionadas
- **ROADMAP.md v4.0**: testes marcados como concluídos, score de maturidade atualizado (~6.8 → ~7.5), status de cada item por fase (concluído/pendente), issues #8 e #10 referenciadas
- **CHANGELOG.md**: criado no formato Keep a Changelog — v0.1.0, v0.2.0 e v0.3.0 registrados
- **CLAUDE.md**: criado com contexto do projeto para o Claude Code — setup, convenções, o que nunca fazer, fluxo de controle de acesso, issues abertas

## Plano de testes

- [ ] Verificar links internos no README (ROADMAP.md, CHANGELOG.md)
- [ ] Confirmar que CLAUDE.md reflete o estado atual do projeto