### PR TITLE
fix(docs): corrige sintaxe erDiagram no ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,13 +222,13 @@ erDiagram
         string s3Key
         string uploadedAt
         string uploadedBy
-        string deletedAt "null = ativa"
+        string deletedAt
     }
 
     ACESS_DENIED_LOGS {
         string email PK
         string timestamp SK
-        string reason "NOT_IN_WHITELIST"
+        string reason
     }
 
     WHITELIST ||--o{ PHOTOS : "usuário faz upload"


### PR DESCRIPTION
## Resumo

Corrige erro de parse no diagrama Mermaid `erDiagram` do `docs/ARCHITECTURE.md`.

## Problema

O Mermaid não suporta strings em aspas como comentários inline em atributos de `erDiagram`. As linhas abaixo causavam o erro `Expecting 'ATTRIBUTE_WORD', got 'COMMENT'`:

```
string deletedAt "null = ativa"
string reason "NOT_IN_WHITELIST"
```

## Correção

Removidas as strings inline dos atributos `deletedAt` e `reason`. O significado de cada campo está documentado na tabela de variáveis de ambiente e nos comentários do código.

## Plano de testes

- [ ] Verificar que o diagrama `erDiagram` renderiza corretamente no GitHub após merge